### PR TITLE
Remove CSS filter for whitelisted domains #36

### DIFF
--- a/roles/nginx/templates/sites-available/upri_cssfilter
+++ b/roles/nginx/templates/sites-available/upri_cssfilter
@@ -17,6 +17,13 @@ server {
         rewrite_by_lua '
             local cssdomain = string.match(ngx.var.uri, "(%w+%.%w+)/")
             local css = require "css"
+
+            local whitelisted = css.is_whitelisted(cssdomain)
+
+            if whitelisted then
+                return ngx.redirect("/whitelist.css")
+            end
+
             local special = css.is_special(cssdomain)
 
             if special then
@@ -46,5 +53,9 @@ server {
             ngx.header["Cache-Control"] = "max-age=86400"
             ngx.print(csscontent)
         ';
+    }
+
+    location ~ ^/whitelist.css {
+        return 204;
     }
 }


### PR DESCRIPTION
Change to nginx CSS lua script to return empty CSS file for (CSS) white-listed domains.