### PR TITLE
change logdir file permissions to fix openvpn startup error

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,6 +14,9 @@
 - name: create directory /var/tmp/log
   file: path=/var/tmp/log state=directory recurse=yes
 
+- name: change permissions for /var/tmp/log
+  file: path=/var/tmp/log state=directory owner=root group=tmp-logger mode=0771
+
 - name: create logging directory /var/log/log for development
   file: path=/var/log/log state=directory owner=root group=tmp-logger mode=0771
   when: env == "development"


### PR DESCRIPTION
- fixes wrong permissions on /var/tmp/log before first reboot