### PR TITLE
workaround for broken ntopng repositories

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -20,7 +20,7 @@ to setup a development environment for the upribox software.
 Prerequisites [on your development machine]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  install *ansible* 2.3.0 (``sudo pip install ansible==2.3.0``) and
+-  install *ansible* 2.3.0, jmespath (``sudo pip install ansible==2.3.0 jmespath``) and
    *git*
 -  install requirements for the *ansible* modules (``sudo apt-get install python-pip python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev libjpeg8-dev zlib1g-dev``)
 -  make sure to log into your Raspberry via SSH once because ansible

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -79,6 +79,9 @@
     # this is needed by ansible for becoming an unprivileged user
     - acl
 
+- name: enable ntp
+  command: timedatectl set-ntp True
+
 - name: update pip via pip
   pip: name=pip state=present version="{{pip_version}}"
 

--- a/roles/ntopng/files/ntop.list
+++ b/roles/ntopng/files/ntop.list
@@ -1,2 +1,6 @@
 deb http://apt-stable.ntop.org/stretch_pi armhf/
 deb http://apt-stable.ntop.org/stretch_pi all/
+# deb http://packages.ntop.org/RaspberryPI/stretch_pi/ all/
+# deb http://packages.ntop.org/RaspberryPI/stretch_pi/ armhf/
+deb http://apt.ntop.org/stretch_pi armhf/
+deb http://apt.ntop.org/stretch_pi all/

--- a/roles/ntopng/tasks/main.yml
+++ b/roles/ntopng/tasks/main.yml
@@ -25,11 +25,39 @@
   when: ansible_distribution_release == "stretch"
 
 - name: install services
-  apt: name={{ item }} state={{ apt_target_state }} force=yes update_cache=yes cache_valid_time={{ "0" if ntopng_res and ntopng_res|changed else apt_cache_time }}
+  apt: name={{ item }} state={{ apt_target_state }} force=yes update_cache=yes
   with_items:
     - redis-server
-    - ntopng
-    - ntopng-data
+    - python-jmespath
+
+- name: try to install latest ntopng stable release
+  block:
+    - name: retrieve latest ntopng release version
+      uri:
+        url: https://api.github.com/repos/ntop/ntopng/releases/latest
+        return_content: yes
+      register: ntop_latest
+
+    - name: install latest ntopng stable
+      apt: name={{ item }} state={{ apt_target_state }} force=yes update_cache=yes cache_valid_time={{ "0" if ntopng_res and ntopng_res|changed else apt_cache_time }}
+      with_items:
+        - ntopng={{ ntop_latest.json.tag_name }}*
+        - ntopng-data
+
+  rescue:
+      # try to install the previous ntopng stable release in case the github repo contains a new stable release,
+      # but the apt repos do not at the moment
+      - name: retrieve all ntopng releases
+        uri:
+          url: https://api.github.com/repos/ntop/ntopng/releases
+          return_content: yes
+        register: ntop_releases
+
+      - name: install previous ntopng stable
+        apt: name={{ item }} state={{ apt_target_state }} force=yes update_cache=yes cache_valid_time={{ "0" if ntopng_res and ntopng_res|changed else apt_cache_time }}
+        with_items:
+          - ntopng={{ (ntop_releases.json | json_query('[?prerelease==`false` && draft==`false`].tag_name') | sort(reverse=True))[1] }}*
+          - ntopng-data
 
 - name: enable services
   service: name={{ item }} enabled=yes use=service


### PR DESCRIPTION
- add other ntpng sources
- check for latest stable release on github
- manually install latest stable or try to install previous stable in case of errors
- workaround for #130